### PR TITLE
Fix feature documentation of function name

### DIFF
--- a/_feature/skip-quoted.html
+++ b/_feature/skip-quoted.html
@@ -48,7 +48,7 @@ status: stable
       </div>
     </div>
     <p>When viewing an email, the
-    <code class="literal">&lt;skip-to-quoted&gt;</code>function (by default the
+    <code class="literal">&lt;skip-quoted&gt;</code>function (by default the
     <code class="literal">S</code> key) will scroll past any email headers or quoted text. Sometimes, a little context is useful.</p>
     <p>By setting the
     <code class="literal">$skip_quoted_offset</code> variable, you can select how much of the quoted text is left visible.</p>


### PR DESCRIPTION
The neomutt source code (functions.h#L370) has this function as <skip-quoted>, not `<skip-to-quoted>`, this fixes the feature documentation to match.